### PR TITLE
Implement exit_hook step called by dehydrated since v0.4.0

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -149,6 +149,9 @@ def invalid_challenge(args):
     logger.info(' + Challenge was invalid, please have a look')
     return
 
+def exit_hook(args):
+    logger.info(' + Exiting OVH hook')
+    return
 
 def main(argv):
     ops = {
@@ -156,7 +159,8 @@ def main(argv):
         'clean_challenge': delete_txt_record,
         'deploy_cert': deploy_cert,
         'unchanged_cert': unchanged_cert,
-        "invalid_challenge": invalid_challenge,
+        'invalid_challenge': invalid_challenge,
+        'exit_hook': exit_hook,
     }
     logger.info(" + OVH hook executing: {0}".format(argv[0]))
     ops[argv[0]](argv[1:])

--- a/hook.py
+++ b/hook.py
@@ -153,6 +153,10 @@ def exit_hook(args):
     logger.info(' + Exiting OVH hook')
     return
 
+def startup_hook(args):
+    logger.info(' + Startup OVH hook')
+    return
+
 def main(argv):
     ops = {
         'deploy_challenge': create_txt_record,
@@ -161,6 +165,7 @@ def main(argv):
         'unchanged_cert': unchanged_cert,
         'invalid_challenge': invalid_challenge,
         'exit_hook': exit_hook,
+        'startup_hook': startup_hook,
     }
     logger.info(" + OVH hook executing: {0}".format(argv[0]))
     ops[argv[0]](argv[1:])


### PR DESCRIPTION
Otherwise, the dehydrated call fails at the end :
~~~
Processing xxxxxxxxxx.xxx with alternative names: www.xxxxxxxxx.net xxxxxxxx.xxxxxx.net
 + Checking domain name(s) of existing cert... unchanged.
 + Checking expire date of existing cert...
 + Valid till Aug 20 00:17:00 2017 GMT (Longer than 30 days). Skipping renew!
 + OVH hook executing: unchanged_cert
 + Certificate still valid. Nothing to do here
 + OVH hook executing: exit_hook
Traceback (most recent call last):
  File "/home/chtitux/prog/dehydrated/hooks/ovh/hook.py", line 166, in <module>
    main(sys.argv[1:])
  File "/home/chtitux/prog/dehydrated/hooks/ovh/hook.py", line 162, in main
    ops[argv[0]](argv[1:])
KeyError: 'exit_hook'

~~~