### PR TITLE
fix(): Handle dns.resolver.NoAnswer exception

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -73,7 +73,7 @@ def check_if_record_is_deployed(domain, dns_record, token):
             for txt_value in txt_values:
                 if token in txt_value:
                     return
-        except dns.resolver.NXDOMAIN:
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
             logger.info(" + Record not available yet. Checking again in 10s...")
         except dns.exception.Timeout:
             logger.info(" + DNS Request timeout. Checking again in 10s...")


### PR DESCRIPTION
This patch fixes the following error : 
```
root@dev:~# dehydrated -d carsso.ovh -d '*.carsso.ovh' -c
# INFO: Using main config file /etc/dehydrated/config
 + OVH hook executing: this_hookscript_is_broken__dehydrated_is_working_fine__please_ignore_unknown_hooks_in_your_script
 + OVH hook: unknown hook function (this_hookscript_is_broken__dehydrated_is_working_fine__please_ignore_unknown_hooks_in_your_script); skipping...
 + OVH hook executing: startup_hook
 + OVH hook: unknown hook function (startup_hook); skipping...
Processing carsso.ovh with alternative names: *.carsso.ovh
 + OVH hook executing: this_hookscript_is_broken__dehydrated_is_working_fine__please_ignore_unknown_hooks_in_your_script
 + OVH hook: unknown hook function (this_hookscript_is_broken__dehydrated_is_working_fine__please_ignore_unknown_hooks_in_your_script); skipping...
 + OVH hook executing: generate_csr
 + OVH hook: unknown hook function (generate_csr); skipping...
 + Signing domains...
 + Generating private key...
 + Generating signing request...
 + Requesting new certificate order from CA...
 + Received 2 authorizations URLs from the CA
 + Handling authorization for carsso.ovh
 + Found valid authorization for carsso.ovh
 + Handling authorization for carsso.ovh
 + 1 pending challenge(s)
 + Deploying challenge tokens...
 + OVH hook executing: deploy_challenge
+ TXT record created, ID: 1530292087
+ Zone refreshed on OVH side
+ SOA SERIAL of zone: 2018031404
Testing DNS record against 213.251.128.153, 2001:41d0:1:1999::1, 213.251.188.153, 2001:41d0:1:4a99::1
Traceback (most recent call last):
  File "/opt/letsencrypt-ovh-hook/hook.py", line 171, in <module>
    main(sys.argv[1:])
  File "/opt/letsencrypt-ovh-hook/hook.py", line 167, in main
    ops[argv[0]](argv[1:])
  File "/opt/letsencrypt-ovh-hook/hook.py", line 108, in create_txt_record
    check_if_record_is_deployed(domain, record_name, token)
  File "/opt/letsencrypt-ovh-hook/hook.py", line 70, in check_if_record_is_deployed
    txt_records = resolver.query('{}.{}'.format(dns_record, domain), 'TXT')
  File "/usr/lib/python2.7/dist-packages/dns/resolver.py", line 1053, in query
    raise_on_no_answer)
  File "/usr/lib/python2.7/dist-packages/dns/resolver.py", line 234, in __init__
    raise NoAnswer(response=response)
dns.resolver.NoAnswer: The DNS response does not contain an answer to the question: _acme-challenge.carsso.ovh. IN TXT
root@dev:~#
```